### PR TITLE
Update rspack prod configuration

### DIFF
--- a/rspack.prod.js
+++ b/rspack.prod.js
@@ -26,25 +26,11 @@ module.exports = merge(common, {
     }]
   },
   plugins: [
-    new rspack.CopyRspackPlugin({
-      patterns: [
-        {
-          from: 'resources/public',
-          filter: (filepath) => !filepath.endsWith('.ejs'),
-          noErrorOnMissing: true
-        }
-      ]
-    }),
     new rspack.CssExtractRspackPlugin({
       filename: '[name].[contenthash].css'
     })
   ].filter(Boolean),
   output: {
     filename: '[name].[contenthash].js'
-  },
-  optimization: {
-    runtimeChunk: {
-      name: 'manifest'
-    }
   }
 });


### PR DESCRIPTION
This updates the production configuration for rspack by:

- removing the unneeded copy plugin (directory `resources/public` does not exist).
- removing the `optimization` config since it breaks the successful loading of the plugin in the gis client.

Please note @terrestris/devs.