### PR TITLE
chore: do not pin node dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":disableRateLimiting"
+    ":disableRateLimiting",
+    ":preserveSemverRanges"
   ]
 }


### PR DESCRIPTION
Use `:preserveSemverRanges` as documented [here](https://docs.renovatebot.com/presets-default/#preservesemverranges)